### PR TITLE
Remove pimcore5 branch from readme, is outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@ Dockerwest Compose Environment for [Pimcore](https://www.pimcore.org/).
 
 For detailed documentation, [visit our website](https://dockerwest.github.io/compose-pimcore/)
 
-
-***When using Pimcore 5, please use the "pimcore5" branch!***
-
-
 Usage
 -----
 


### PR DESCRIPTION
Pimcore5 is supported by default in master branch