### PR TITLE
Forward mysql ports to be able to use de mysql on the dinghy machine

### DIFF
--- a/docker-compose-dinghy.yml
+++ b/docker-compose-dinghy.yml
@@ -14,6 +14,8 @@ services:
       - DOMAIN_NAME=mysql.${BASEHOST:-pimcore.docker}
     command: --innodb-doublewrite=0 --innodb-large-prefix=1 --innodb-file-format=Barracuda --innodb-page-size=32K
     network_mode: bridge
+    ports:
+     - 3306:3306
 
   mailcatcher:
     image: mailhog/mailhog


### PR DESCRIPTION
I had problems trying to connect to the mysql in dinghy (xhvye) , only when i forwarded the ports i was able to connect to it