### PR TITLE
Improve detection of active containers to support docker-compose v2

### DIFF
--- a/bin/composer
+++ b/bin/composer
@@ -22,7 +22,7 @@ env = Environment(composepath + '/.env')
 
 cmd = [
     os.path.dirname(sys.argv[0]) + '/run',
-    'ps', 'application'
+    'ps', '--services', '--filter', 'status=running'
 ]
 
 p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
@@ -36,6 +36,7 @@ except KeyboardInterrupt:
     p.wait()
 out, err = p.communicate()
 out = out.decode('utf-8')
+runningContainers = out.splitlines()
 
 dockerrun = ['docker', 'run', '--rm']
 if sys.stdin.isatty() and sys.stdout.isatty():
@@ -43,7 +44,7 @@ if sys.stdin.isatty() and sys.stdout.isatty():
 
 cmd = dockerrun
 
-if re.search('Up', out):
+if 'application' in runningContainers:
     containercmd = [
         os.path.dirname(sys.argv[0]) + '/run',
         'ps', '-q', 'application'

--- a/bin/composer1
+++ b/bin/composer1
@@ -22,7 +22,7 @@ env = Environment(composepath + '/.env')
 
 cmd = [
     os.path.dirname(sys.argv[0]) + '/run',
-    'ps', 'application'
+    'ps', '--services', '--filter', 'status=running'
 ]
 
 p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
@@ -36,6 +36,7 @@ except KeyboardInterrupt:
     p.wait()
 out, err = p.communicate()
 out = out.decode('utf-8')
+runningContainers = out.splitlines()
 
 dockerrun = ['docker', 'run', '--rm']
 if sys.stdin.isatty() and sys.stdout.isatty():
@@ -43,7 +44,7 @@ if sys.stdin.isatty() and sys.stdout.isatty():
 
 cmd = dockerrun
 
-if re.search('Up', out):
+if 'application' in runningContainers:
     containercmd = [
         os.path.dirname(sys.argv[0]) + '/run',
         'ps', '-q', 'application'

--- a/bin/mysql
+++ b/bin/mysql
@@ -13,7 +13,7 @@ env = Environment(composepath + '/.env')
 
 cmd = [
     os.path.dirname(sys.argv[0]) + '/run',
-    'ps', 'mysql'
+    'ps', '--services', '--filter', 'status=running'
 ]
 
 p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
@@ -27,8 +27,9 @@ except KeyboardInterrupt:
     p.wait()
 out, err = p.communicate()
 out = out.decode('utf-8')
+runningContainers = out.splitlines()
 
-if not re.search('Up', out):
+if not 'mysql' in runningContainers:
     raise Exception('We need a running mysql server')
 
 cmd = [

--- a/bin/mysqldump
+++ b/bin/mysqldump
@@ -13,7 +13,7 @@ env = Environment(composepath + '/.env')
 
 cmd = [
     os.path.dirname(sys.argv[0]) + '/run',
-    'ps', 'mysql'
+    'ps', '--services', '--filter', 'status=running'
 ]
 
 p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
@@ -27,8 +27,9 @@ except KeyboardInterrupt:
     p.wait()
 out, err = p.communicate()
 out = out.decode('utf-8')
+runningContainers = out.splitlines()
 
-if not re.search('Up', out):
+if not 'mysql' in runningContainers:
     raise Exception('We need a running mysql server')
 
 cmd = [

--- a/bin/mysqlimport
+++ b/bin/mysqlimport
@@ -16,7 +16,7 @@ if len(sys.argv) <= 1:
 
 cmd = [
     os.path.dirname(sys.argv[0]) + '/run',
-    'ps', 'mysql'
+    'ps', '--services', '--filter', 'status=running'
 ]
 
 p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
@@ -30,8 +30,9 @@ except KeyboardInterrupt:
     p.wait()
 out, err = p.communicate()
 out = out.decode('utf-8')
+runningContainers = out.splitlines()
 
-if not re.search('Up', out):
+if not 'mysql' in runningContainers:
     raise Exception('We need a running mysql server')
 
 cmd = [

--- a/bin/php
+++ b/bin/php
@@ -13,7 +13,7 @@ env = Environment(composepath + '/.env')
 
 cmd = [
     os.path.dirname(sys.argv[0]) + '/run',
-    'ps', 'application'
+    'ps', '--services', '--filter', 'status=running'
 ]
 
 p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
@@ -27,8 +27,9 @@ except KeyboardInterrupt:
     p.wait()
 out, err = p.communicate()
 out = out.decode('utf-8')
+runningContainers = out.splitlines()
 
-if re.search('Up', out):
+if 'application' in runningContainers:
     dockerrun = [os.path.dirname(sys.argv[0]) + '/run', 'exec']
     if not sys.stdin.isatty() or not sys.stdout.isatty():
         dockerrun += ['-T']

--- a/bin/redis-cli
+++ b/bin/redis-cli
@@ -13,7 +13,7 @@ env = Environment(composepath + '/.env')
 
 cmd = [
     os.path.dirname(sys.argv[0]) + '/run',
-    'ps', 'redis'
+    'ps', '--services', '--filter', 'status=running'
 ]
 
 p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
@@ -27,8 +27,9 @@ except KeyboardInterrupt:
     p.wait()
 out, err = p.communicate()
 out = out.decode('utf-8')
+runningContainers = out.splitlines()
 
-if not re.search('Up', out):
+if not 'redis' in runningContainers:
     raise Exception('We need a running redis server')
 
 dockerrun = [os.path.dirname(sys.argv[0]) + '/run', 'exec']


### PR DESCRIPTION
On docker-compose v1.x, this is the output of `run ps application`:

```
              Name                        Command              State        Ports
-----------------------------------------------------------------------------------
<someproject>_application_1   /startup.sh php-fpm7.4   Up (healthy)   9000/tcp
```

On docker-compose v2.x (currently in beta), the same command returns:

```
              Name                        Command              State        Ports
-----------------------------------------------------------------------------------
<someproject>_application_1   /startup.sh php-fpm7.4   running (healthy)   9000/tcp
```

Note the running container state is listed as "running" instead of "Up" in the newer version. This breaks compatibility with the current active container detection logic.
Instead of searching for both "Up" and "running" (which might break again sooner or later), I suggest to --filter the run ps output to only show running containers.
--filter 'status=running' is compatible with docker-compose v1.x and v2.x.
I'm also passing the --services argument to return a list of only the docker-compose service names, that we can search through to find the required container and determine that it is running.
