### PR TITLE
Add MariaDB support

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -41,6 +41,20 @@ BASEHOST=pimcore.docker
 EXTRAHOSTS=www.pimcore.docker
 
 #
+#Choose whether you want to use mariadb or mysql depending on the server setup of your project.
+#Rule of thumb = Mariadb is preffered when using >PimcoreX
+#
+DBMS=mysql
+#DBMS=mariadb
+
+# Choose your MySQL version. To see which versions are available see
+# https://github.com/docker-library/mysql
+#
+# In case you use mariadb, check the tags on docker:
+# https://hub.docker.com/_/mariadb?tab=tags&page=1&ordering=last_updated
+#
+MYSQLVERSION=8
+
 # Choose whatever you want to use as default mysql root password.
 #
 MYSQL_ROOT_PASSWORD=toor
@@ -55,12 +69,6 @@ APPLICATION=../pimcore
 # enable timestamp checking in opcache.
 #
 DEVELOPMENT=1
-
-#
-# Choose your MySQL version. To see which versions are available see
-# https://github.com/docker-library/mysql
-#
-MYSQLVERSION=8
 
 #
 # Set the default window manager when running the environment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - DOMAIN_NAME=redis.${BASEHOST:-pimcore.docker}
 
   mysql:
-    image: docker.io/library/mysql:${MYSQLVERSION:-8}
+    image: docker.io/library/${DBMS:-mysql}:${MYSQLVERSION:-8}
     environment:
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-toor}
       - DOMAIN_NAME=mysql.${BASEHOST:-pimcore.docker}


### PR DESCRIPTION
New instances of Pimcore X are now frequently making use of MariaDB.
Support for MariaDB was added to make sure that local machines can run on the same specs.